### PR TITLE
Get `rake console` working for new projects

### DIFF
--- a/lib/event_sourcery_generators/generators/templates/project/rakefile.tt
+++ b/lib/event_sourcery_generators/generators/templates/project/rakefile.tt
@@ -4,3 +4,7 @@ task :console => :environment do
   ARGV.clear
   IRB.start
 end
+
+task :environment do
+  require 'bundler/setup'
+end


### PR DESCRIPTION
A couple of fixes:
- Don't require gem tasks: as we don't have a gem spec this doesn't work.
- Define an `environment` rake task: the `console` task has a dependency on this.
