### PR TITLE
Add explicit requires for generated commands

### DIFF
--- a/lib/event_sourcery_generators/generators/templates/command/api_endpoint.rb.tt
+++ b/lib/event_sourcery_generators/generators/templates/command/api_endpoint.rb.tt
@@ -1,3 +1,5 @@
+        require 'commands/<%= aggregate %>/<%= command %>/command'
+        require 'commands/<%= aggregate %>/<%= command %>/command_handler'
         app.post '/<%= aggregate.pluralize %>/:aggregate_id/<%= command %>' do
           command = <%= aggregate.camelize %>::<%= command.camelize %>::Command.build!(
             aggregate_id: params[:aggregate_id],

--- a/lib/event_sourcery_generators/generators/templates/command/command_handler.rb.tt
+++ b/lib/event_sourcery_generators/generators/templates/command/command_handler.rb.tt
@@ -1,3 +1,6 @@
+require 'commands/<%= aggregate_name %>/<%= aggregate_name %>'
+require 'commands/<%= aggregate_name %>/repository'
+
 module <%= project_name.camelize %>
   module <%= aggregate_class_name %>
     module <%= command_class_name %>

--- a/lib/event_sourcery_generators/generators/templates/command/repository.rb.tt
+++ b/lib/event_sourcery_generators/generators/templates/command/repository.rb.tt
@@ -1,3 +1,5 @@
+require 'commands/<%= aggregate_name %>/<%= aggregate_name %>'
+
 module <%= project_name.camelize %>
   module <%= aggregate_class_name %>
     class Repository

--- a/lib/event_sourcery_generators/generators/templates/project/web.rb.tt
+++ b/lib/event_sourcery_generators/generators/templates/project/web.rb.tt
@@ -1,5 +1,6 @@
 require 'sinatra/base'
 require 'better_errors'
+require 'event_sourcery'
 
 require 'app/command/api'
 require 'app/query/api'


### PR DESCRIPTION
Be explicit about the dependencies in-app. This gets my generated command almost working. There're still a couple of missing classes in the EventSourcery gem: `CommandHandler` and `AggregateRoot`.
