### PR TITLE
Ignore .ruby-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg/
+/.ruby-version
 /Gemfile.lock


### PR DESCRIPTION
Allows developers to use whichever Ruby version they desire, without creating a dirty working tree.
