### PR TITLE
Fix typo in name of Procfile template

### DIFF
--- a/lib/event_sourcery_generators/generators/project.rb
+++ b/lib/event_sourcery_generators/generators/project.rb
@@ -47,7 +47,7 @@ module EventSourceryGenerators
       end
 
       def setup_processes_infrastructure
-        template('Procfile.tt', "#{project_name}/Procfile")
+        template('procfile.tt', "#{project_name}/Procfile")
         template('config.ru.tt', "#{project_name}/config.ru")
         template('app.json.tt', "#{project_name}/app.json")
       end


### PR DESCRIPTION
There's a typo in the procfile template name. The generator is looking for `Procfile.tt` but the template is actually called `procfile.tt`. I corrected the generator so it looks for `procfile.tt` but outputs `Procfile`