### PR TITLE
Generate the same project name multiple times when generating

### DIFF
--- a/lib/event_sourcery_generators/cli.rb
+++ b/lib/event_sourcery_generators/cli.rb
@@ -2,6 +2,7 @@ require 'thor'
 require 'active_support/inflector'
 require 'verbs'
 
+require 'event_sourcery_generators/event_sourcery_project'
 require 'event_sourcery_generators/generators/project'
 require 'event_sourcery_generators/generators/command'
 require 'event_sourcery_generators/generators/query'

--- a/lib/event_sourcery_generators/event_sourcery_project.rb
+++ b/lib/event_sourcery_generators/event_sourcery_project.rb
@@ -1,0 +1,28 @@
+class EventSourceryProject
+  EVENT_SOURCERY_APP_NAME_FILE = 'event_sourcery_app_name'
+  attr_accessor :project_root, :project_name
+
+  # @return [EventSourceryProject]
+  def self.find()
+
+    # code from Rails https://github.com/rails/rails/blob/master/railties/lib/rails/app_loader.rb, under MIT license
+    original_cwd = Dir.pwd
+
+    loop do
+      if (File.file?(EVENT_SOURCERY_APP_NAME_FILE))
+        esp = EventSourceryProject.new
+        esp.project_root = Dir.pwd
+        esp.project_name = File.read(EVENT_SOURCERY_APP_NAME_FILE)
+        Dir.chdir(original_cwd)
+        return esp
+      end
+
+      # If we exhaust the search there is no executable, this could be a
+      # call to generate a new application, so restore the original cwd.
+      Dir.chdir(original_cwd) && return if Pathname.new(Dir.pwd).root?
+
+      # Otherwise keep moving upwards in search of an executable.
+      Dir.chdir("..")
+    end
+  end
+end

--- a/lib/event_sourcery_generators/generators/command.rb
+++ b/lib/event_sourcery_generators/generators/command.rb
@@ -11,7 +11,7 @@ module EventSourceryGenerators
       end
 
       def create_or_inject_into_aggregate_file
-        aggregate_file = "app/aggregates/#{aggregate_name}.rb"
+        aggregate_file = "#{project_root}/app/aggregates/#{aggregate_name}.rb"
 
         @command_method     = erb_file('aggregate/command_method.rb.tt')
         @apply_event_method = erb_file('aggregate/apply_event_method.rb.tt')
@@ -25,11 +25,11 @@ module EventSourceryGenerators
       end
 
       def create_command_file
-        template('command.rb.tt', "app/commands/#{aggregate}/#{command}.rb")
+        template('command.rb.tt', "#{project_root}/app/commands/#{aggregate}/#{command}.rb")
       end
 
       def create_event
-        event_file = "app/events/#{event_name}.rb"
+        event_file = "#{project_root}/app/events/#{event_name}.rb"
 
         unless File.exist?(event_file)
           template('event.rb.tt', event_file)
@@ -37,7 +37,7 @@ module EventSourceryGenerators
       end
 
       def inject_command_to_api
-        insert_into_file('app/web/server.rb', after: "< Sinatra::Base\n") do
+        insert_into_file("#{project_root}/app/web/server.rb", after: "< Sinatra::Base\n") do
           erb_file('api_endpoint.rb.tt')
         end
       end
@@ -75,11 +75,24 @@ module EventSourceryGenerators
       end
 
       def project_name
-        @project_name ||= File.split(Dir.pwd).last
+        event_sourcery_project.project_name
+      end
+
+      def project_root
+        event_sourcery_project.project_root
       end
 
       def project_class_name
         @project_class_name ||= project_name.underscore.camelize
+      end
+
+      def event_sourcery_project
+        @event_sourcery_project ||= EventSourceryProject.find()
+        unless @event_sourcery_project
+          raise ArgumentError, "must be in an event sourcery directory"
+        end
+
+        @event_sourcery_project
       end
     end
   end

--- a/lib/event_sourcery_generators/generators/project.rb
+++ b/lib/event_sourcery_generators/generators/project.rb
@@ -47,9 +47,13 @@ module EventSourceryGenerators
       end
 
       def setup_processes_infrastructure
-        template('Procfile.tt', "#{project_name}/Procfile")
+        template('procfile.tt', "#{project_name}/Procfile")
         template('config.ru.tt', "#{project_name}/config.ru")
         template('app.json.tt', "#{project_name}/app.json")
+      end
+
+      def setup_app_name_file
+        template('event_sourcery_app_name.tt', "#{project_name}/event_sourcery_app_name")
       end
 
       def run_setup_script

--- a/lib/event_sourcery_generators/generators/project.rb
+++ b/lib/event_sourcery_generators/generators/project.rb
@@ -47,7 +47,7 @@ module EventSourceryGenerators
       end
 
       def setup_processes_infrastructure
-        template('Procfile.tt', "#{project_name}/Procfile")
+        template('procfile.tt', "#{project_name}/Procfile")
         template('config.ru.tt', "#{project_name}/config.ru")
         template('app.json.tt', "#{project_name}/app.json")
       end

--- a/lib/event_sourcery_generators/generators/reactor.rb
+++ b/lib/event_sourcery_generators/generators/reactor.rb
@@ -11,17 +11,21 @@ module EventSourceryGenerators
       end
 
       def create_reactor
-        template('reactor.rb.tt', "app/reactors/#{reactor_name}.rb")
+        template('reactor.rb.tt', "#{project_root}/app/reactors/#{reactor_name}.rb")
       end
 
       def add_reactor_to_rakefile
-        insert_into_file('Rakefile', erb_file('reactor_process.tt'), after: "processors = [\n")
+        insert_into_file("#{project_root}/Rakefile", erb_file('reactor_process.tt'), after: "processors = [\n")
       end
 
       private
 
       def project_name
-        @project_name ||= File.split(Dir.pwd).last
+        event_sourcery_project.project_name
+      end
+
+      def project_root
+        event_sourcery_project.project_root
       end
 
       def project_class_name
@@ -35,6 +39,15 @@ module EventSourceryGenerators
       def erb_file(file)
         path = File.join(self.class.source_root, file)
         ERB.new(::File.binread(path), nil, "-", "@output_buffer").result(binding)
+      end
+
+      def event_sourcery_project
+        @event_sourcery_project ||= EventSourceryProject.find()
+        unless @event_sourcery_project
+          raise ArgumentError, "must be in an event sourcery directory"
+        end
+
+        @event_sourcery_project
       end
     end
   end

--- a/lib/event_sourcery_generators/generators/templates/project/event_sourcery_app_name.tt
+++ b/lib/event_sourcery_generators/generators/templates/project/event_sourcery_app_name.tt
@@ -1,0 +1,1 @@
+<%= project_class_name %>


### PR DESCRIPTION
I found two related problems in the generator. 

First, running eventsourcery generate:[command, event, query] uses the current directory's name for the module name in newly generated files. If you're in the root of your eventsourcery project and the directory's name hasn't changed, this works great. The problem occurs when your root directory's name has changed, such as when you're running in vagrant and it's mounted at `/vagrant` running in the subdirectory of your project. If you do that, newly generated files use the new name of the directory for creating the file's module name. 

Second, if you're in a subdirectory of your project, eventsourcery will treat your current location as the root of the project. This leads to files in completely wrong places.

This patch fixes this by doing the following:
* When creating a project, a file called `event_sourcery_app_name` is placed in the root of the your project. It contains the project name the user passed in originally.
* When running any of the `generate` generators, the generator will look for `event_sourcery_app_name` in the current directory and then walk up the file system to find that file. If it doesn't, it raises an exception. If it does, the generators use the directory `event_sourcery_app_name` is in as the project root and the contents of the file as the project name for modules.

Note: using the `event_sourcery_app_name` file seemed the most straightforward solution at the time. I considered looking for the project name by looking for the `config/environment.rb` file. While slightly more difficult to implement, I also wasn't sure if people would change that file in a way which would break the search.